### PR TITLE
Add contact and mission pages

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,5 +33,15 @@ def home():
 
     return render_template("index.html", response=response_text)
 
+
+@app.route("/contact")
+def contact():
+    return render_template("contact.html")
+
+
+@app.route("/mission")
+def mission():
+    return render_template("mission.html")
+
 if __name__ == "__main__":
     app.run(debug=True)

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Live Bible</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            padding-top: 70px;
+            background-color: #f5f7fa;
+        }
+        .response-box {
+            margin-top: 1.5rem;
+            padding: 1.25rem;
+            background-color: #fff;
+            border-left: 5px solid #0d6efd;
+            white-space: pre-wrap;
+        }
+    </style>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
+  <div class="container">
+    <a class="navbar-brand" href="/">Live Bible</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item">
+          <a class="nav-link" href="/mission">Our Mission</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="/contact">Contact</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container">
+    {% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="mb-4">Contact Us</h1>
+<p class="lead">Feel free to reach out anytime!</p>
+<ul class="list-unstyled">
+    <li><strong>Email:</strong> your.email@example.com</li>
+    <li><strong>Instagram:</strong> @yourhandle</li>
+</ul>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,44 +1,16 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Live Bible</title>
-    <meta charset="UTF-8">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
-    <style>
-        body {
-            font-family: 'Inter', sans-serif;
-            padding-top: 60px;
-            background-color: #f5f7fa;
-        }
-
-        .response-box {
-            margin-top: 1.5rem;
-            padding: 1.25rem;
-            background-color: #fff;
-            border-left: 5px solid #0d6efd;
-            white-space: pre-wrap;
-        }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <h1 class="mb-4">Live Bible</h1>
-        <form method="post">
-            <div class="mb-3">
-                <label for="prompt" class="form-label">What are you struggling with?</label>
-                <textarea id="prompt" name="prompt" rows="4" class="form-control" required></textarea>
-            </div>
-            <button type="submit" class="btn btn-primary">Get Guidance</button>
-        </form>
-
-        {% if response %}
-            <div class="response-box mt-4">
-                {{ response }}
-            </div>
-        {% endif %}
+{% extends "base.html" %}
+{% block content %}
+<h1 class="mb-4">Live Bible</h1>
+<form method="post">
+    <div class="mb-3">
+        <label for="prompt" class="form-label">What are you struggling with?</label>
+        <textarea id="prompt" name="prompt" rows="4" class="form-control" required></textarea>
     </div>
-</body>
-</html>
+    <button type="submit" class="btn btn-primary">Get Guidance</button>
+</form>
+{% if response %}
+    <div class="response-box mt-4">
+        {{ response }}
+    </div>
+{% endif %}
+{% endblock %}

--- a/templates/mission.html
+++ b/templates/mission.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="mb-4">Our Mission</h1>
+<p class="lead">We believe the Bible offers hope and comfort for anyone facing life's challenges.</p>
+<p>By combining timeless scripture with the speed of AI, we aim to provide encouragement and guidance as quickly as possible to those in need.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Bootstrap-based base layout with nav links
- update index page to extend layout
- add contact page with email and Instagram handle
- add mission page describing project purpose
- route `/contact` and `/mission` in Flask app

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6862ae049a6c83318b28b1498d68c6a9