### PR TITLE
Enhance UI with dark mode and help resources

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,5 +43,21 @@ def contact():
 def mission():
     return render_template("mission.html")
 
+
+@app.route("/help")
+def help_page():
+    return render_template("help.html")
+
+
+@app.route("/verse")
+def verse():
+    verses = [
+        "For God so loved the world, that he gave his only Son (John 3:16)",
+        "The LORD is my shepherd; I shall not want (Psalm 23:1)",
+        "I can do all things through Christ who strengthens me (Philippians 4:13)",
+    ]
+    import random
+    return render_template("verse.html", verse=random.choice(verses))
+
 if __name__ == "__main__":
     app.run(debug=True)

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,6 +21,17 @@
             border-left: 5px solid #0d6efd;
             white-space: pre-wrap;
         }
+        .dark-mode {
+            background-color: #121212;
+            color: #f8f9fa;
+        }
+        .dark-mode .navbar {
+            background-color: #343a40 !important;
+        }
+        .dark-mode .response-box {
+            background-color: #1e1e1e;
+            border-left-color: #0d6efd;
+        }
     </style>
 </head>
 <body>
@@ -33,10 +44,22 @@
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav ms-auto">
         <li class="nav-item">
+          <a class="nav-link" href="/">Home</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href="/mission">Our Mission</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="/contact">Contact</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="/help">Get Help</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="/verse">Verse of the Day</a>
+        </li>
+        <li class="nav-item d-flex align-items-center">
+          <button class="btn btn-sm btn-outline-secondary" id="themeToggle">Dark Mode</button>
         </li>
       </ul>
     </div>
@@ -46,5 +69,14 @@
     {% block content %}{% endblock %}
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  const toggle = document.getElementById('themeToggle');
+  if (toggle) {
+    toggle.addEventListener('click', () => {
+      document.body.classList.toggle('dark-mode');
+      toggle.textContent = document.body.classList.contains('dark-mode') ? 'Light Mode' : 'Dark Mode';
+    });
+  }
+</script>
 </body>
 </html>

--- a/templates/help.html
+++ b/templates/help.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="mb-4">Get Help</h1>
+<p class="lead">If you need additional support, please reach out to these resources:</p>
+<ul class="list-unstyled">
+  <li><strong>National Suicide Prevention Lifeline:</strong> 988</li>
+  <li><strong>Substance Abuse Helpline:</strong> 1-800-662-4357</li>
+  <li><strong>Domestic Violence Hotline:</strong> 1-800-799-7233</li>
+</ul>
+<p class="mt-4">Looking for a church community? Try searching "churches near me" on your favorite maps app.</p>
+{% endblock %}

--- a/templates/verse.html
+++ b/templates/verse.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="mb-4">Verse of the Day</h1>
+<p class="fs-5">{{ verse }}</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add dark mode styles and toggle script
- expose home page link, Get Help page, and verse of the day page
- create help page with hotline numbers
- add verse of the day page with random verse

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6862b3242998833196389c267df3b2d1