### PR TITLE
Add switch-style dark mode and verse explanation

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,12 +52,22 @@ def help_page():
 @app.route("/verse")
 def verse():
     verses = [
-        "For God so loved the world, that he gave his only Son (John 3:16)",
-        "The LORD is my shepherd; I shall not want (Psalm 23:1)",
-        "I can do all things through Christ who strengthens me (Philippians 4:13)",
+        {
+            "text": "For God so loved the world, that he gave his only Son (John 3:16)",
+            "meaning": "God's love is sacrificial and available to everyone. Embrace this love and share it with others."
+        },
+        {
+            "text": "The LORD is my shepherd; I shall not want (Psalm 23:1)",
+            "meaning": "Trust that God will guide and provide for you, even when life feels uncertain."
+        },
+        {
+            "text": "I can do all things through Christ who strengthens me (Philippians 4:13)",
+            "meaning": "With Christ's help you can face any challenge that comes your way."
+        },
     ]
     import random
-    return render_template("verse.html", verse=random.choice(verses))
+    selection = random.choice(verses)
+    return render_template("verse.html", verse=selection["text"], meaning=selection["meaning"])
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/templates/base.html
+++ b/templates/base.html
@@ -28,6 +28,10 @@
         .dark-mode .navbar {
             background-color: #343a40 !important;
         }
+        .dark-mode .nav-link,
+        .dark-mode .navbar-brand {
+            color: #f8f9fa !important;
+        }
         .dark-mode .response-box {
             background-color: #1e1e1e;
             border-left-color: #0d6efd;
@@ -46,11 +50,14 @@
         <li class="nav-item">
           <a class="nav-link" href="/">Home</a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link" href="/mission">Our Mission</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="/contact">Contact</a>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="aboutDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            About
+          </a>
+          <ul class="dropdown-menu" aria-labelledby="aboutDropdown">
+            <li><a class="dropdown-item" href="/mission">Our Mission</a></li>
+            <li><a class="dropdown-item" href="/contact">Contact</a></li>
+          </ul>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="/help">Get Help</a>
@@ -58,8 +65,11 @@
         <li class="nav-item">
           <a class="nav-link" href="/verse">Verse of the Day</a>
         </li>
-        <li class="nav-item d-flex align-items-center">
-          <button class="btn btn-sm btn-outline-secondary" id="themeToggle">Dark Mode</button>
+        <li class="nav-item d-flex align-items-center ms-lg-3">
+          <div class="form-check form-switch m-0">
+            <input class="form-check-input" type="checkbox" role="switch" id="themeToggle">
+            <label class="form-check-label" for="themeToggle" id="themeLabel">Dark Mode</label>
+          </div>
         </li>
       </ul>
     </div>
@@ -71,10 +81,11 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <script>
   const toggle = document.getElementById('themeToggle');
+  const label = document.getElementById('themeLabel');
   if (toggle) {
-    toggle.addEventListener('click', () => {
+    toggle.addEventListener('change', () => {
       document.body.classList.toggle('dark-mode');
-      toggle.textContent = document.body.classList.contains('dark-mode') ? 'Light Mode' : 'Dark Mode';
+      label.textContent = document.body.classList.contains('dark-mode') ? 'Light Mode' : 'Dark Mode';
     });
   }
 </script>

--- a/templates/verse.html
+++ b/templates/verse.html
@@ -2,4 +2,7 @@
 {% block content %}
 <h1 class="mb-4">Verse of the Day</h1>
 <p class="fs-5">{{ verse }}</p>
+{% if meaning %}
+<p class="mt-3">{{ meaning }}</p>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- switch dark mode button for a checkbox toggle
- ensure nav and brand text turn white in dark mode
- group Contact and Mission under an "About" dropdown to declutter the nav
- show random verse with a short explanation

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6862b4c6a08c8331b694a7d70cbcc99e