### PR TITLE
Add verse search and refresh layout

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,25 +49,36 @@ def help_page():
     return render_template("help.html")
 
 
-@app.route("/verse")
-def verse():
-    verses = [
-        {
-            "text": "For God so loved the world, that he gave his only Son (John 3:16)",
-            "meaning": "God's love is sacrificial and available to everyone. Embrace this love and share it with others."
-        },
-        {
-            "text": "The LORD is my shepherd; I shall not want (Psalm 23:1)",
-            "meaning": "Trust that God will guide and provide for you, even when life feels uncertain."
-        },
-        {
-            "text": "I can do all things through Christ who strengthens me (Philippians 4:13)",
-            "meaning": "With Christ's help you can face any challenge that comes your way."
-        },
-    ]
-    import random
-    selection = random.choice(verses)
-    return render_template("verse.html", verse=selection["text"], meaning=selection["meaning"])
+@app.route("/verses", methods=["GET", "POST"])
+def verses():
+    """Return encouraging verses based on a user supplied topic."""
+    results = ""
+    topic = ""
+    if request.method == "POST":
+        topic = request.form["topic"]
+
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "Provide three short Bible verses with references that speak to "
+                    "the given topic. Keep the tone uplifting and return them in "
+                    "bullet form."
+                ),
+            },
+            {"role": "user", "content": topic},
+        ]
+
+        try:
+            response = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=messages,
+            )
+            results = response["choices"][0]["message"]["content"].strip()
+        except Exception as e:
+            results = f"❌ Error: {e}"
+
+    return render_template("verses.html", topic=topic, results=results)
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
@@ -20,21 +21,6 @@
             background-color: #fff;
             border-left: 5px solid #0d6efd;
             white-space: pre-wrap;
-        }
-        .dark-mode {
-            background-color: #121212;
-            color: #f8f9fa;
-        }
-        .dark-mode .navbar {
-            background-color: #343a40 !important;
-        }
-        .dark-mode .nav-link,
-        .dark-mode .navbar-brand {
-            color: #f8f9fa !important;
-        }
-        .dark-mode .response-box {
-            background-color: #1e1e1e;
-            border-left-color: #0d6efd;
         }
     </style>
 </head>
@@ -63,13 +49,7 @@
           <a class="nav-link" href="/help">Get Help</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/verse">Verse of the Day</a>
-        </li>
-        <li class="nav-item d-flex align-items-center ms-lg-3">
-          <div class="form-check form-switch m-0">
-            <input class="form-check-input" type="checkbox" role="switch" id="themeToggle">
-            <label class="form-check-label" for="themeToggle" id="themeLabel">Dark Mode</label>
-          </div>
+          <a class="nav-link" href="/verses">Find Encouraging Verses</a>
         </li>
       </ul>
     </div>
@@ -79,15 +59,5 @@
     {% block content %}{% endblock %}
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-<script>
-  const toggle = document.getElementById('themeToggle');
-  const label = document.getElementById('themeLabel');
-  if (toggle) {
-    toggle.addEventListener('change', () => {
-      document.body.classList.toggle('dark-mode');
-      label.textContent = document.body.classList.contains('dark-mode') ? 'Light Mode' : 'Dark Mode';
-    });
-  }
-</script>
 </body>
 </html>

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -3,7 +3,7 @@
 <h1 class="mb-4">Contact Us</h1>
 <p class="lead">Feel free to reach out anytime!</p>
 <ul class="list-unstyled">
-    <li><strong>Email:</strong> your.email@example.com</li>
-    <li><strong>Instagram:</strong> @yourhandle</li>
+    <li><i class="fa-solid fa-envelope me-2"></i><a href="mailto:asklivebible@gmail.com">asklivebible@gmail.com</a></li>
+    <li><i class="fa-brands fa-instagram me-2"></i><a href="https://instagram.com/live.bible" target="_blank">@live.bible</a></li>
 </ul>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,13 +1,17 @@
 {% extends "base.html" %}
 {% block content %}
-<h1 class="mb-4">Live Bible</h1>
-<form method="post">
-    <div class="mb-3">
-        <label for="prompt" class="form-label">What are you struggling with?</label>
-        <textarea id="prompt" name="prompt" rows="4" class="form-control" required></textarea>
+<h1 class="mb-4 text-center">Live Bible</h1>
+<div class="row justify-content-center">
+    <div class="col-md-8 col-lg-6">
+        <form method="post">
+            <div class="mb-3">
+                <label for="prompt" class="form-label">What are you struggling with?</label>
+                <textarea id="prompt" name="prompt" rows="4" class="form-control" required></textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">Ask for Guidance</button>
+        </form>
     </div>
-    <button type="submit" class="btn btn-primary">Get Guidance</button>
-</form>
+</div>
 {% if response %}
     <div class="response-box mt-4">
         {{ response }}

--- a/templates/verse.html
+++ b/templates/verse.html
@@ -1,8 +1,0 @@
-{% extends "base.html" %}
-{% block content %}
-<h1 class="mb-4">Verse of the Day</h1>
-<p class="fs-5">{{ verse }}</p>
-{% if meaning %}
-<p class="mt-3">{{ meaning }}</p>
-{% endif %}
-{% endblock %}

--- a/templates/verses.html
+++ b/templates/verses.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="mb-4">Find Encouraging Verses</h1>
+<form method="post" class="mb-3">
+    <div class="mb-3">
+        <label for="topic" class="form-label">What topic would you like help with?</label>
+        <input type="text" id="topic" name="topic" class="form-control" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Search</button>
+</form>
+{% if results %}
+    <div class="response-box mt-4">
+        {{ results }}
+    </div>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- replace the random verse page with a new verse search powered by OpenAI
- remove dark mode option and update navigation
- tweak the home page layout
- refresh contact information with email and Instagram icons

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_686532668490833188746f44f7cb8e06