### PR TITLE
Enhance contact page and verse results

### DIFF
--- a/main.py
+++ b/main.py
@@ -61,9 +61,9 @@ def verses():
             {
                 "role": "system",
                 "content": (
-                    "Provide three short Bible verses with references that speak to "
-                    "the given topic. Keep the tone uplifting and return them in "
-                    "bullet form."
+                    "Provide five short Bible verses with references that speak to "
+                    "the given topic. Keep the tone uplifting and return them as "
+                    "bullet points with a blank line between each item for easy reading."
                 ),
             },
             {"role": "user", "content": topic},

--- a/templates/base.html
+++ b/templates/base.html
@@ -58,6 +58,9 @@
 <div class="container">
     {% block content %}{% endblock %}
 </div>
+<footer class="bg-light text-center py-3 mt-5">
+    <small>&copy; 2024 Live Bible. All rights reserved.</small>
+</footer>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -1,9 +1,17 @@
 {% extends "base.html" %}
 {% block content %}
-<h1 class="mb-4">Contact Us</h1>
-<p class="lead">Feel free to reach out anytime!</p>
-<ul class="list-unstyled">
-    <li><i class="fa-solid fa-envelope me-2"></i><a href="mailto:asklivebible@gmail.com">asklivebible@gmail.com</a></li>
-    <li><i class="fa-brands fa-instagram me-2"></i><a href="https://instagram.com/live.bible" target="_blank">@live.bible</a></li>
-</ul>
+<div class="row justify-content-center">
+    <div class="col-md-8 col-lg-6">
+        <div class="card shadow-sm">
+            <div class="card-body text-center">
+                <h1 class="card-title mb-4">Contact Us</h1>
+                <p class="lead">Feel free to reach out anytime!</p>
+                <ul class="list-unstyled mb-0">
+                    <li class="mb-2"><i class="fa-solid fa-envelope me-2"></i><a href="mailto:asklivebible@gmail.com">asklivebible@gmail.com</a></li>
+                    <li><i class="fa-brands fa-instagram me-2"></i><a href="https://instagram.com/live.bible" target="_blank">@live.bible</a></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/templates/verses.html
+++ b/templates/verses.html
@@ -10,7 +10,13 @@
 </form>
 {% if results %}
     <div class="response-box mt-4">
-        {{ results }}
+        <ul class="list-unstyled">
+            {% for line in results.split('\n') %}
+                {% if line.strip() %}
+                    <li class="mb-3">{{ line }}</li>
+                {% endif %}
+            {% endfor %}
+        </ul>
     </div>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- restyle contact page with a centered card
- show verse results as a bulleted list
- request 5 verses from the assistant for better spacing
- add a simple site footer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686534fbc69483318a88599e192d34a2