### PR TITLE
Improve site style

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -4,7 +4,7 @@ function initShareButton() {
   btn.addEventListener('click', async () => {
     const shareData = {
       title: 'LiveBible',
-      text: 'Find biblical encouragement at LiveBible',
+      text: 'Get quick encouragement with LiveBible',
       url: 'https://livebible.live',
     };
     if (navigator.share) {

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,13 +18,18 @@
         body {
             font-family: 'Inter', sans-serif;
             padding-top: 70px;
-            background-color: #f5f7fa;
+            background: linear-gradient(135deg, #f0f4ff, #e0e5ff);
+            min-height: 100vh;
+        }
+        .navbar {
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
         }
         .response-box {
             margin-top: 1.5rem;
             padding: 1.25rem;
             background-color: #fff;
-            border-left: 5px solid #0d6efd;
+            border-left: 5px solid #6366f1;
+            border-radius: 0.25rem;
             white-space: pre-wrap;
         }
     </style>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% block content %}
-<h1 class="mb-4 text-center">LiveBible</h1>
+<div class="text-center mb-4">
+    <h1 class="display-4 fw-semibold">Instant Encouragement</h1>
+    <p class="lead">Share what's on your heart and receive verses and prayer.</p>
+</div>
 <div class="row justify-content-center">
     <div class="col-md-8 col-lg-6">
         <form method="post">


### PR DESCRIPTION
## Summary
- refine homepage tagline
- freshen design with gradient background and subtle nav shadow
- tone down repeated branding in share text

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68655a15da54833191f42b88ff660616