### PR TITLE
Add usage tracking and PayPal details

### DIFF
--- a/frontend/templates/about.html
+++ b/frontend/templates/about.html
@@ -6,18 +6,4 @@
 <p>We combine trusted translations with modern AI to deliver thoughtful responses in seconds.</p>
 <h2 class="mt-5">Why Trust Us</h2>
 <p>Our team is passionate about making God's Word accessible to all.</p>
-<div class="row justify-content-center">
-  <div class="col-md-4 testimonial">
-    <blockquote class="blockquote mb-2">
-      <p class="mb-0">"LiveBible helps me prep for sermons on the go."</p>
-      <footer class="blockquote-footer">Pastor Jane Smith</footer>
-    </blockquote>
-  </div>
-  <div class="col-md-4 testimonial">
-    <blockquote class="blockquote mb-2">
-      <p class="mb-0">"An invaluable tool for our youth ministry."</p>
-      <footer class="blockquote-footer">Pastor Isaiah Turner</footer>
-    </blockquote>
-  </div>
-</div>
 {% endblock %}

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -30,6 +30,11 @@
     </div>
   </div>
 </nav>
+{% if usage_count is not none %}
+<div class="alert alert-info text-center small mb-2 usage-count">
+    Free uses today: {{ usage_count }}/{{ usage_limit }}
+</div>
+{% endif %}
 <div class="container my-4">
     {% block content %}{% endblock %}
 </div>

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -49,25 +49,5 @@
         <div class="logo-placeholder">Logo 2</div>
         <div class="logo-placeholder">Logo 3</div>
     </div>
-    <div class="row justify-content-center">
-        <div class="col-md-4 testimonial">
-            <blockquote class="blockquote mb-2">
-                <p class="mb-0">"This tool has been a blessing for our small group."</p>
-                <footer class="blockquote-footer">Pastor John Doe</footer>
-            </blockquote>
-        </div>
-        <div class="col-md-4 testimonial">
-            <blockquote class="blockquote mb-2">
-                <p class="mb-0">"I recommend LiveBible to anyone needing quick inspiration."</p>
-                <footer class="blockquote-footer">Pastor Mary Johnson</footer>
-            </blockquote>
-        </div>
-        <div class="col-md-4 testimonial">
-            <blockquote class="blockquote mb-2">
-                <p class="mb-0">"A great resource for daily devotionals on the go."</p>
-                <footer class="blockquote-footer">Pastor Luke Thompson</footer>
-            </blockquote>
-        </div>
-    </div>
 </div>
 {% endblock %}

--- a/frontend/templates/upgrade.html
+++ b/frontend/templates/upgrade.html
@@ -9,12 +9,16 @@
 <div class="text-center">
   <a href="/contact" class="btn btn-outline-secondary">Contact Us</a>
 </div>
-<script src="https://www.paypal.com/sdk/js?client-id=sb&currency=USD"></script>
+<script src="https://www.paypal.com/sdk/js?client-id={{ paypal_client_id }}&currency=USD"></script>
 <script>
   paypal.Buttons({
     createOrder: function(data, actions) {
       return actions.order.create({
-        purchase_units: [{ amount: { value: '9.00' } }]
+        purchase_units: [{
+          amount: { value: '9.00' },
+          payee: { email_address: '{{ paypal_email }}' }
+        }],
+        application_context: { brand_name: 'LiveBible' }
       });
     },
     onApprove: function(data, actions) {


### PR DESCRIPTION
## Summary
- remove pastor testimonials from about and homepage
- show current daily usage count to users
- set up PayPal payment to warnerussery22@gmail.com with LiveBible branding
- expose PAYPAL_* env vars for upgrade flow

## Testing
- `python -m py_compile backend/app.py`
- `python -m py_compile main.py`
- `python -m black --check backend/app.py`
- ❌ `python main.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686d42e20f3c833195c3401ab2cf62d6