### PR TITLE
Improve design, remove placeholder logos

### DIFF
--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -1,7 +1,7 @@
 body {
     font-family: 'Inter', sans-serif;
     padding-top: 70px;
-    background-color: #ffffff;
+    background: linear-gradient(135deg, #ffffff, #f8f9fa);
     min-height: 100vh;
 }
 .navbar {
@@ -37,16 +37,9 @@ body {
     border-color: #0c4128;
     box-shadow: 0 0 8px rgba(15, 81, 50, 0.6);
 }
-.logo-placeholder {
-    background-color: #f0f0f0;
-    height: 50px;
-    width: 120px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    margin: 0 10px;
-    font-weight: bold;
-    color: #666;
+
+.trusted-icon {
+    color: #0f5132;
 }
 
 .testimonial {

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -7,6 +7,7 @@
     <title>{% block title %}LiveBible{% endblock %}</title>
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ctext y='14'%3E%F0%9F%93%96%3C/text%3E%3C/svg%3E">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -45,9 +45,9 @@
     <h2 class="mb-4">Why Trust Us</h2>
     <p class="mb-3">LiveBible is used by believers around the world seeking quick encouragement.</p>
     <div class="d-flex justify-content-center mb-4">
-        <div class="logo-placeholder">Logo 1</div>
-        <div class="logo-placeholder">Logo 2</div>
-        <div class="logo-placeholder">Logo 3</div>
+        <i class="fa-solid fa-person-praying fa-2x mx-3 trusted-icon"></i>
+        <i class="fa-solid fa-church fa-2x mx-3 trusted-icon"></i>
+        <i class="fa-solid fa-users fa-2x mx-3 trusted-icon"></i>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- load Font Awesome in base layout
- remove placeholder logos from homepage
- add Faith-based icons in their place
- tweak styles with subtle gradient and color classes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d526ac07883318709ecf14a5971b0