### PR TITLE
Add copy verses button & tweak call-to-action

### DIFF
--- a/frontend/static/script.js
+++ b/frontend/static/script.js
@@ -13,6 +13,23 @@ function initShareButton() {
   });
 }
 
+function initCopyVersesButton() {
+  const btn = document.getElementById('copyVersesButton');
+  const container = document.getElementById('versesContainer');
+  if (!btn || !container) return;
+  btn.addEventListener('click', async () => {
+    const text = container.innerText.trim();
+    try {
+      await navigator.clipboard.writeText(text);
+      btn.innerText = 'Copied!';
+      setTimeout(() => (btn.innerText = 'Copy Verses'), 2000);
+    } catch (err) {
+      prompt('Copy these verses:', text);
+    }
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   initShareButton();
+  initCopyVersesButton();
 });

--- a/frontend/templates/faq.html
+++ b/frontend/templates/faq.html
@@ -47,7 +47,7 @@
     </h2>
     <div id="a4" class="accordion-collapse collapse" aria-labelledby="q4" data-bs-parent="#faqAccordion">
       <div class="accordion-body">
-        Absolutely! Use the copy link button to quickly send encouragement to others.
+        Absolutely! Use the copy link button or the new "Copy Verses" option to quickly share encouragement with others.
       </div>
     </div>
   </div>

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -3,7 +3,7 @@
 <div class="text-center mb-5">
     <h1 class="display-4 fw-semibold">Faith-Based Answers in Seconds</h1>
     <p class="lead">Get personalized verses and prayers for any situation.</p>
-    <a href="#ask" class="btn btn-primary">Get Started</a>
+    <a href="/verses" class="btn btn-primary">Explore Verses</a>
 </div>
 <div class="row text-center mb-5">
     <div class="col-md-4">

--- a/frontend/templates/verses.html
+++ b/frontend/templates/verses.html
@@ -9,7 +9,7 @@
     <button type="submit" class="btn btn-primary">Search</button>
 </form>
 {% if results %}
-    <div class="response-box mt-4">
+    <div class="response-box mt-4" id="versesContainer">
         <ul class="list-unstyled">
             {% for line in results.split('\n') %}
                 {% if line.strip() %}
@@ -17,6 +17,11 @@
                 {% endif %}
             {% endfor %}
         </ul>
+    </div>
+    <div class="text-center mt-3">
+        <button id="copyVersesButton" class="btn btn-outline-secondary">
+            <i class="fa-solid fa-copy"></i> Copy Verses
+        </button>
     </div>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- send users to the verses page with an "Explore Verses" button
- let users copy verses results to clipboard
- support the new copy feature in JavaScript
- mention copying verses in FAQ

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d6511dc0c8331b49e20b13b5b8cb3